### PR TITLE
Fix typo in URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer="Martín Gaitán",
     maintainer_email="gaitan@gmail.com",
     license="MIT",
-    url="https://github.com/mgaitan/pytest-leak_finder",
+    url="https://github.com/mgaitan/pytest-leak-finder",
     description="Find the previous test that makes another to fail",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- otherwise the link in PyPi is broken

Noticed this accidentally while checking the plugin (I wrote a [somewhat related plugin](https://github.com/mrbean-bremen/pytest-find-dependencies) some time ago). 