### PR TITLE
Add a backtrack option to save time in case of clustered leaks.

### DIFF
--- a/tests/test_leak_finder.py
+++ b/tests/test_leak_finder.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 import pytest
+
 from pytest_leak_finder import bizect
 
 
@@ -8,7 +8,7 @@ def module_with_a_leaking_test(testdir):
     testdir.makepyfile(
         """
     l = []
-    
+
     def test1():
         assert True
 
@@ -22,7 +22,7 @@ def module_with_a_leaking_test(testdir):
         l.append("leak")
         assert True
 
-    
+
     def test4():
         assert True
 
@@ -77,6 +77,22 @@ def test_3rd_run_set_target(testdir, module_with_a_leaking_test):
         ]
     )
     assert result.ret == 1
+
+
+def test_backtrack(testdir, module_with_a_leaking_test):
+    testdir.runpytest("--leak-finder")
+    testdir.runpytest("--leak-finder")
+    testdir.runpytest("--leak-finder")
+    result = testdir.runpytest("--leak-finder", "-v", "--backtrack=2")
+
+    result.stdout.fnmatch_lines(
+        [
+            "Target set to: test_backtrack.py::test5",
+            "Next step: a",
+            "Current target is: test_backtrack.py::test5",
+        ]
+    )
+    assert result.ret == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Scenario in which this is useful:

A large codebase, with multiple leaking tests that all affect a single target.

It's likely (though not guaranteed) that the tests that are leaking resources that affect the one target test are clustered together. In that case, after finding one problematic test and skipping or fixing it, it can be helpful to run the same set of tests under pytest-leak-finder again to find if there are other leaks. 

With this PR, you can for instance run `pytest --leak-finder --backtrack=2` to rerun after finding a failing test in path `abbbab`, starting with path `abbb`.